### PR TITLE
delay関数で、MIPSコアタイマー(CP0)を使うように変更。

### DIFF
--- a/delay.c
+++ b/delay.c
@@ -1,19 +1,33 @@
-/* 
+/*
  * File:   delay.c
  * Author: 164
  *
  * Created on July 25, 2019, 11:13 AM
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <xc.h>
 #include "delay.h"
 
-/*
- * 
- */
-void delay(int n){ 
-    n = n * 500;
-    while(n>0) {n--;}
+#if !defined(_XTAL_FREQ)
+#define _XTAL_FREQ 20000000
+#endif
+
+
+static void delay_ticks( uint32_t ticks )
+{
+  uint32_t t_start = _CP0_GET_COUNT();
+
+  while( (_CP0_GET_COUNT() - t_start) < ticks )
+    ;
 }
 
+// emulate PIC16/24 delay function.
+void __delay_us( uint32_t us )
+{
+  delay_ticks( us * (_XTAL_FREQ/2/1000000) );
+}
+
+void __delay_ms( uint32_t ms )
+{
+  delay_ticks( ms * (_XTAL_FREQ/2/1000) );
+}

--- a/delay.h
+++ b/delay.h
@@ -15,8 +15,8 @@
  */
 /* ************************************************************************** */
 
-#ifndef _EXAMPLE_FILE_NAME_H    /* Guard against multiple inclusion */
-#define _EXAMPLE_FILE_NAME_H
+#ifndef _DELAY_H    /* Guard against multiple inclusion */
+#define _DELAY_H
 
 
 /* ************************************************************************** */
@@ -29,19 +29,25 @@
  */
 /* TODO:  Include other files here if needed. */
 
+#include <stdint.h>
 
 /* Provide C++ Compatibility */
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void delay(int);
+void __delay_us( uint32_t us );
+void __delay_ms( uint32_t ms );
+
+static inline void delay( int n ) {
+  __delay_ms( n );
+}
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* _EXAMPLE_FILE_NAME_H */
+#endif /* _DELAY_H */
 
 /* *****************************************************************************
  End of File

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 // USERID = No Setting
 #pragma config PMDL1WAY = ON            // Peripheral Module Disable Configuration (Allow only one reconfiguration)
 #pragma config IOL1WAY = ON             // Peripheral Pin Select Configuration (Allow only one reconfiguration)
-                                                                                                                
+
 // DEVCFG2
 #pragma config FPLLIDIV = DIV_2         // PLL Input Divider (2x Divider)
 #pragma config FPLLMUL = MUL_20         // PLL Multiplier (20x Multiplier)
@@ -83,9 +83,9 @@ int check_timeout(void)
     int i;
     for( i = 0; i < 50; i++ ) {
         PORTAbits.RA0 = 1;
-        delay( 100 );
+        __delay_ms( 30 );
         PORTAbits.RA0 = 0;
-        delay( 100 );
+        __delay_ms( 30 );
         if(U1STAbits.URXDA){
             U1RXREG = 0;
             return 1;
@@ -113,7 +113,7 @@ int main(void){
     uart_init();
     timer_init();
     pin_init();
-    
+
     /*Enable the interrupt*/
     IPC9bits.U2IP = 4;
     IPC9bits.U2IS = 3;
@@ -130,12 +130,12 @@ int main(void){
     IPC2bits.T2IP = 2;
     IPC2bits.T2IS = 0;
     INTCONbits.MVEC = 1;
-    
+
     if (check_timeout()){
         /* IDE code */
         add_code();
     };
-    
+
     /* mruby/c */
     mrbc_init(memory_pool, MEMORY_SIZE);
     mrbc_define_method(0, mrbc_class_object, "pinInit", c_pin_init);

--- a/mrbc_firm.h
+++ b/mrbc_firm.h
@@ -27,11 +27,13 @@
 #define MAX_SIZE (1024 * 40)
 #define ROW_SIZE (PAGE_SIZE / sizeof(uint8_t) / 8)
 
+#define ROW_COUNT(byte_size) ((byte_size) / ROW_SIZE + (byte_size % ROW_SIZE != 0))
+
 /* Provide C++ Compatibility */
 #ifdef __cplusplus
 extern "C" {
 #endif
-    
+
 uint8_t *loadFlush();
 void add_code();
 


### PR DESCRIPTION
正確性が上がります。
PIC24等で使う事ができた、__delay_ms 関数等と互換性を持ちます。
_XTAL_FREQの define が必要です。
