### PR TITLE
メモリ不足に対処

### DIFF
--- a/main.c
+++ b/main.c
@@ -42,7 +42,7 @@
 // Use project enums instead of #define for ON and OFF.
 
 
-#define MEMORY_SIZE (1024*20)
+#define MEMORY_SIZE (1024*40)
 uint8_t memory_pool[MEMORY_SIZE];
 uint8_t t_count = 0;
 

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -118,7 +118,8 @@
         <property key="place-data-into-section" value="false"/>
         <property key="post-instruction-scheduling" value="default"/>
         <property key="pre-instruction-scheduling" value="default"/>
-        <property key="preprocessor-macros" value="MRBC_USE_HAL_PIC32"/>
+        <property key="preprocessor-macros"
+                  value="MRBC_USE_HAL_PIC32;UART_SIZE_RXFIFO=1024"/>
         <property key="strict-ansi" value="false"/>
         <property key="support-ansi" value="false"/>
         <property key="toplevel-reordering" value=""/>
@@ -173,7 +174,7 @@
         <property key="generate-16-bit-code" value="false"/>
         <property key="generate-cross-reference-file" value="false"/>
         <property key="generate-micro-compressed-code" value="false"/>
-        <property key="heap-size" value="1023"/>
+        <property key="heap-size" value="0x2000"/>
         <property key="input-libraries" value=""/>
         <property key="kseg-length" value=""/>
         <property key="kseg-origin" value=""/>
@@ -188,7 +189,7 @@
         <property key="report-memory-usage" value="false"/>
         <property key="serial-length" value=""/>
         <property key="serial-origin" value=""/>
-        <property key="stack-size" value="1023"/>
+        <property key="stack-size" value="0x2000"/>
         <property key="symbol-stripping" value=""/>
         <property key="trace-symbols" value=""/>
         <property key="warn-section-align" value="false"/>


### PR DESCRIPTION
メモリ不足が発生するとのフィードバックにより、RAM64KBを可能な限り使うように mruby/c ヒープ、stack、heapの量を調整しました。
