### PR TITLE
UARTクラスへ、set_modem_paramsメソッドを追加したいです。

### DIFF
--- a/main.c
+++ b/main.c
@@ -54,6 +54,12 @@ int hal_flush(int fd) {
     return 0;
 }
 
+void _mon_putc( char c )
+{
+  uart_write(&uart1_handle, &c, 1);
+}
+
+
 void pin_init(void){
     ANSELA = 0;
     ANSELB = 0;
@@ -105,9 +111,10 @@ void __ISR(_TIMER_2_VECTOR, IPL2AUTO) _T2Interrupt (  ){
     IFS0CLR = 1 << _IFS0_T2IF_POSITION;
 }
 
-int main(void){
-    //__XC_UART = 1;
 
+
+int main(void)
+{
     /* module init */
     pin_init();
     i2c_init();

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -10,7 +10,7 @@
             <cpp-extensions/>
             <header-extensions>h</header-extensions>
             <asminc-extensions/>
-            <sourceEncoding>ISO-8859-1</sourceEncoding>
+            <sourceEncoding>UTF-8</sourceEncoding>
             <make-dep-projects/>
             <sourceRootList>
                 <sourceRootElem>.</sourceRootElem>

--- a/uart.h
+++ b/uart.h
@@ -34,33 +34,21 @@ extern "C" {
   UART Handle
 */
 typedef struct UART_HANDLE {
+  uint8_t number;
   uint8_t rx_overflow;		// buffer overflow flag.
   uint8_t delimiter;
+  uint8_t txd_pin;
 
   volatile uint16_t rx_rd;	// index of rxfifo for read.
   volatile uint16_t rx_wr;	// index of rxfifo for write.
   volatile uint8_t rxfifo[UART_SIZE_RXFIFO]; // FIFO for received data.
 
-  void (*set_baudrate)();
   void (*clear_rx_buffer)();
   int (*write)();
 
 } UART_HANDLE;
 
 extern UART_HANDLE uart1_handle, uart2_handle;
-
-
-//================================================================
-/*! set baud-rate
-
-  @memberof UART_HANDLE
-  @param  uh		Pointer of UART_HANDLE.
-  @param  baudrate	baudrate.
-*/
-static inline void uart_set_baudrate( const UART_HANDLE *uh, int baudrate )
-{
-  uh->set_baudrate( baudrate );
-}
 
 
 //================================================================
@@ -129,14 +117,13 @@ static inline int uart_puts( UART_HANDLE *uh, const void *s )
 }
 
 
-
-
 /* C codes */
 void uart_init(void);
+void uart_enable(const UART_HANDLE *uh, int en_dis);
+int uart_set_modem_params(UART_HANDLE *uh, int baud, int parity, int stop_bits, int txd, int rxd);
 int uart_read(UART_HANDLE *uh, void *buffer, size_t size);
-int uart_bytes_available(UART_HANDLE *uh);
-int uart_can_read_line(UART_HANDLE *uh);
-
+int uart_bytes_available(const UART_HANDLE *uh);
+int uart_can_read_line(const UART_HANDLE *uh);
 
 /* mruby/c codes */
 void mrbc_init_class_uart(struct VM *vm);


### PR DESCRIPTION
ボーレートを任意のタイミングで変更したり、ストップビットが 2bit のアプリケーションが出てきました。rubygemsのserialportライブラリを調べたら set_modem_params() メソッドを使って可能のようですので、Rboardのファームウェアにも、それを模倣して同メソッドを作ってみました。
```
uart.set_modem_params( "baud"=>9600, "stop_bits"=>2)
```
また、PICのポート割り付けを変更すれば、grove digital 端子に UART2を割り付けることが可能でしたので、その機能も追加しています。
```
uart.set_modem_params( "txd"=>15, "rxd"=>16 )
```
