### PR TITLE
派生開発のための weak 属性の追加

### DIFF
--- a/PIC32MX170F256B/model_dependent.c
+++ b/PIC32MX170F256B/model_dependent.c
@@ -52,6 +52,7 @@ volatile uint32_t *TBL_RPxnR[] = { &RPA0R, &RPB0R, &RPC0R };
 
 /*! Initializes the device to the default states configured.
 */
+__attribute__((weak))
 void system_init()
 {
   /*
@@ -109,6 +110,7 @@ void system_init()
   @param num	LED number. 1 origin.
   @param on_off	ON or OFF (True or False)
 */
+__attribute__((weak))
 void onboard_led( int num, int on_off )
 {
   switch( num ) {
@@ -125,6 +127,7 @@ void onboard_led( int num, int on_off )
   @param num	SW number. 1 origin.
   @return	1 is OFF, 0 is ON.
 */
+__attribute__((weak))
 int onboard_sw( int num )
 {
   return PORTBbits.RB7;

--- a/mrbc_firm.c
+++ b/mrbc_firm.c
@@ -274,7 +274,7 @@ void add_code(void)
       }
     }
 
-    u_puts("-ERR Illegal command.");
+    mrbc_printf("-ERR Illegal command. '%s'\n", token);
 
   DONE:
     ;


### PR DESCRIPTION
機種依存ディレクトリにある `model_dependent.c` ファイルの関数を簡易的に差し替えができるよう、gcc拡張のweak属性をつけておきたく思います。Rboard を使う、もしくはその回路を流用したものを作る場合に、他のファイルへの変更を最小限にできる可能性を期待するものです。
