### PR TITLE
mrbファイル書き込み時の、境界値バグの修正

### DIFF
--- a/PIC32MX170F256B/model_dependent.h
+++ b/PIC32MX170F256B/model_dependent.h
@@ -95,8 +95,7 @@ extern volatile uint32_t *TBL_RPxnR[];
 #define FLASH_PAGE_SIZE 1024
 #define FLASH_ROW_SIZE (FLASH_PAGE_SIZE / 8)
 #define FLASH_ALIGN_ROW_SIZE(bytes) \
-  ((((bytes)-1) / FLASH_ROW_SIZE + 1) * FLASH_ROW_SIZE)
-
+  ((bytes) + ((FLASH_ROW_SIZE - (bytes)) & (FLASH_ROW_SIZE-1)))
 
 // System clock.
 #if !defined(_XTAL_FREQ)

--- a/main.c
+++ b/main.c
@@ -150,7 +150,7 @@ int main(void)
   const uint8_t *fl_addr = (uint8_t*)FLASH_SAVE_ADDR;
   static const char RITE[4] = "RITE";
   while( strncmp( (const char *)fl_addr, RITE, sizeof(RITE)) == 0 ) {
-    mrbc_create_task(fl_addr, 0);
+    if( ! mrbc_create_task(fl_addr, 0) ) return 1;
 
     // get a next irep.
     uint32_t size = 0;

--- a/mrbc_firm.c
+++ b/mrbc_firm.c
@@ -178,7 +178,7 @@ static int cmd_write(void)
     goto DONE;
   }
 
-  while( prog_end_addr > next_page_top ) {
+  while( next_page_top < prog_end_addr ) {
     if( flash_erase_page( next_page_top ) != 0 ) {
       u_puts("-ERR Flash erase error.");
       goto DONE;
@@ -194,6 +194,12 @@ static int cmd_write(void)
     }
     p_irep_write += FLASH_ROW_SIZE;
     p += FLASH_ROW_SIZE;
+  }
+
+  // Check if magic word "RITE" remains on the next rows.
+  if( strncmp( (const char *)p_irep_write, RITE, sizeof(RITE)) == 0 ) {
+    // erase it.
+    flash_erase_page( p_irep_write );
   }
 
   u_puts("+DONE");


### PR DESCRIPTION
mrbファイルのサイズが、たまたまフラッシュメモリのページサイズ境界にかかったときに発生していた境界値バグを修正しました。
